### PR TITLE
Reproduction and notes reguarding the ember data errors issue

### DIFF
--- a/packages/-ember-data/tests/unit/utils/determine-body-promise-test.js
+++ b/packages/-ember-data/tests/unit/utils/determine-body-promise-test.js
@@ -106,4 +106,15 @@ module('Unit | determineBodyPromise', function() {
       assert.deepEqual(body, undefined, 'body response of null does not throw error HEAD calls');
     });
   });
+
+  test('determineBodyResponse returns errors when errors are present', function(assert) {
+    assert.expect(1);
+
+    const response = new Response(`{"errors":[{"detail":"can't be blank","source":{"pointer":"/data/attributes/email"},"title":"Invalid Attribute"},{"detail":"can't be blank","source":{"pointer":"/data/attributes/name"},"title":"Invalid Attribute"}]}"', { status: 422 }`);
+    const bodyPromise = determineBodyPromise(response, {});
+
+    return bodyPromise.then(body => {
+      assert.equal(body.errors, 2, 'Returns two errors with the payload');
+    });
+  });
 });

--- a/packages/adapter/addon/-private/utils/determine-body-promise.ts
+++ b/packages/adapter/addon/-private/utils/determine-body-promise.ts
@@ -18,6 +18,7 @@ function _determineContent(response: Response, requestData: JQueryAjaxSettings, 
   let ret: Payload = payload;
   let error;
 
+  // RL1: If this returns only when response.ok, would this mean errors payload is never serialized?
   if (!response.ok) {
     return payload;
   }

--- a/packages/adapter/addon/rest.js
+++ b/packages/adapter/addon/rest.js
@@ -741,6 +741,10 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
 
     const data = serializeIntoHash(store, type, snapshot);
 
+    // RL0:
+    // If the return below returns InvalidError, errors show up on model as expected
+    // https://github.com/emberjs/data/blob/master/packages/-ember-data/tests/integration/records/error-test.js#L203
+    // I don't think this will ever throw InvalidError with the right errors for the model
     return this.ajax(url, 'POST', { data });
   },
 
@@ -910,7 +914,10 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
   handleResponse(status, headers, payload, requestData) {
     if (this.isSuccess(status, headers, payload)) {
       return payload;
-    } else if (this.isInvalid(status, headers, payload)) {
+    } else if (this.isInvalid(status, headers, payload)) { // RLX: Payload is sitll a string
+      // Note x:
+      // It looks like "payload.errors" would never be serialized properly here.
+      // i.e. payload is always a string and invalid error will never return appropriate errors to model
       return new InvalidError(payload.errors);
     }
 
@@ -1007,6 +1014,8 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
           return determineBodyPromise(response, requestData);
         })
         .then(payload => {
+          // Payloads from errors are never serialized by here
+          // always a string
           if (_response.ok && !(payload instanceof Error)) {
             return fetchSuccessHandler(adapter, payload, _response, requestData);
           } else {
@@ -1262,6 +1271,7 @@ function ajaxError(adapter, payload, requestData, responseData) {
     error = handleAbort(requestData, responseData);
   } else {
     try {
+      // RLX: Payload is still a string.
       error = adapter.handleResponse(
         responseData.status,
         responseData.headers,

--- a/packages/adapter/addon/rest.js
+++ b/packages/adapter/addon/rest.js
@@ -914,8 +914,8 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
   handleResponse(status, headers, payload, requestData) {
     if (this.isSuccess(status, headers, payload)) {
       return payload;
-    } else if (this.isInvalid(status, headers, payload)) { // RLX: Payload is sitll a string
-      // Note x:
+    } else if (this.isInvalid(status, headers, payload)) {
+      // RL5: Payload is sitll a string
       // It looks like "payload.errors" would never be serialized properly here.
       // i.e. payload is always a string and invalid error will never return appropriate errors to model
       return new InvalidError(payload.errors);
@@ -1014,7 +1014,7 @@ const RESTAdapter = Adapter.extend(BuildURLMixin, {
           return determineBodyPromise(response, requestData);
         })
         .then(payload => {
-          // Payloads from errors are never serialized by here
+          // RL: 2 Payloads from errors are never serialized by here
           // always a string
           if (_response.ok && !(payload instanceof Error)) {
             return fetchSuccessHandler(adapter, payload, _response, requestData);
@@ -1271,7 +1271,7 @@ function ajaxError(adapter, payload, requestData, responseData) {
     error = handleAbort(requestData, responseData);
   } else {
     try {
-      // RLX: Payload is still a string.
+      // RL4: Payload is still a string.
       error = adapter.handleResponse(
         responseData.status,
         responseData.headers,
@@ -1317,6 +1317,7 @@ function fetchErrorHandler(adapter, payload, response, errorThrown, requestData)
   } else {
     responseData.errorThrown = errorThrown;
   }
+  // RL3
   return ajaxError(adapter, payload, requestData, responseData);
 }
 


### PR DESCRIPTION
 It appears errors from the server never get serialized and so never get applied back to the model.

[RL0](https://github.com/ryanlabouve/data/pull/1/files#diff-ad84fbc878beedc97078e5053b8e41d7R744): Attempting to call save => createRecord
[RL1](#): Called [determineBodyReponse](https://github.com/ryanlabouve/data/pull/1/files#diff-ad84fbc878beedc97078e5053b8e41d7L1007) in `this.ajax` would never serialize the payload to json. 
![HuntxWeb 2020-01-30 10-00-18](https://user-images.githubusercontent.com/1318878/73466813-ffb4cf00-4347-11ea-8328-a84f9c9af19c.png). I think [this test](https://github.com/ryanlabouve/data/pull/1/files#diff-ee42d173aa6da77ae34b83db6a684a29R110) should pass if this were to work as expected.
[RL2](https://github.com/ryanlabouve/data/pull/1/files#diff-ad84fbc878beedc97078e5053b8e41d7R1017): Since the response is an error, we invoke (fetchErrorHandler)[https://github.com/ryanlabouve/data/pull/1/files#diff-ad84fbc878beedc97078e5053b8e41d7R1022])

[RL3](https://github.com/ryanlabouve/data/pull/1/files#diff-ad84fbc878beedc97078e5053b8e41d7R1320): Which eventually returns ajaxError and inside ajaxError (adapter.handleResponse)[https://github.com/ryanlabouve/data/pull/1/files#diff-ad84fbc878beedc97078e5053b8e41d7R1274](RL4) is eventually invoked

[RL5](https://github.com/ryanlabouve/data/pull/1/files#diff-ad84fbc878beedc97078e5053b8e41d7R918) In handleResponse, we would never return the `InvalidError` object we need for model errors to work appropriately because `payload` is always a string and `payload.errors` would always be undefined instead of an array of errors ((like the test indicates it should work)[https://github.com/emberjs/data/blob/85dbc55e7989157307ab897ac0b126bd777a724b/packages/-ember-data/tests/integration/records/error-test.js#L202])




